### PR TITLE
Add 1.0.1 release information to EE4J_8 branch. Raise snapshot version.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.json.bind</groupId>
     <artifactId>jakarta.json.bind-api</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>JSON-B API</name>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2016, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2016, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.json.bind</groupId>
     <artifactId>jakarta.json.bind-api</artifactId>
-    <version>1.0.1-SNAPSHOT</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>JSON-B API</name>


### PR DESCRIPTION
I'm releasing JSON-B API 1.0.1 to central based on it's status in https://docs.google.com/spreadsheets/d/18mv1Kx6w2AhHJQEP-Mump-3cxFHx4CnvWEHVAkc8ZgU/edit#gid=0

https://jenkins.eclipse.org/jsonb/job/nexus-staging/17/console ob passed so release is done.
Now it's time to merge release branch to EE4J_8.

1.0.1-BRANCH can be deleted after merge.