### PR TITLE
Fix copyright and enforcer plugins setup.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -521,11 +521,6 @@
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>1.6</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
-                </plugin>
             </plugins>
         </pluginManagement>
 

--- a/etc/config/copyright-exclude
+++ b/etc/config/copyright-exclude
@@ -30,3 +30,4 @@ spec-license.html
 copyright-exclude
 api/etc/config/copyright.txt
 nb-configuration.xml
+api/src/main/javadoc/doc-files/EFSL.html

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -72,8 +72,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8.0,1.9.0)</version>
-                                    <message>You need JDK8 or lower</message>
+                                    <version>[1.8.0,)</version>
+                                    <message>You need JDK8 or later</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>


### PR DESCRIPTION
This fixes issue #153 .
Added api/src/main/javadoc/doc-files/EFSL.html to copyright check excludes
Modified enforcer plugin for spec project to accept JDK 8 and later