### PR TITLE
Rolling back to JSONP 1.1.5

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -90,7 +90,7 @@
         <non.final>false</non.final>
         <skip.release.tests>false</skip.release.tests>
         <spec.version>1.1</spec.version>
-        <jakarta.json.version>1.1.6</jakarta.json.version>
+        <jakarta.json.version>1.1.5</jakarta.json.version>
         <api_package>jakarta.json.bind</api_package>
         <legal.doc.source>${project.basedir}/..</legal.doc.source>
         <vendor.name>Oracle Corporation</vendor.name>


### PR DESCRIPTION
JSONP 1.1.6 has not been released to public yet.

Signed-off-by: Dmitry Kornilov <dmitry.kornilov@oracle.com>