### PR TITLE
Fix API build failure on copyright plugin

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -435,16 +435,12 @@
                 <plugin>
                     <groupId>org.glassfish.copyright</groupId>
                     <artifactId>glassfish-copyright-maven-plugin</artifactId>
-                    <version>1.50</version>
+                    <version>2.3</version>
                     <configuration>
                         <excludeFile>${basedir}/../etc/config/copyright-exclude</excludeFile>
-                        <!--svn|mercurial|git - defaults to svn-->
                         <scm>git</scm>
-                        <!-- turn on/off debugging -->
                         <debug>false</debug>
-                        <!-- skip files not under SCM-->
                         <scmOnly>true</scmOnly>
-                        <!-- turn off warnings -->
                         <warn>false</warn>
                         <!-- for use with repair -->
                         <update>false</update>


### PR DESCRIPTION
Jenkins master build is failing with this error:

```
[ERROR] Failed to execute goal org.glassfish.copyright:glassfish-copyright-maven-plugin:1.50:check (default) 
on project jakarta.json.bind-api: Unable to parse configuration of mojo org.glassfish.copyright:glassfish-copyright-maven-plugin:1.50:check for parameter resources: 
Cannot assign configuration entry 'resources' with value 'null' of type org.apache.maven.model.merge.ModelMerger.MergingList to property of type java.util.ArrayList -> [Help 1]
```

Upgrading to the newest version of the glassfish-copyright plugin seems to fix the issue.