### PR TITLE
fix: bundle manifest 3.0.2

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -395,6 +395,10 @@
                 <artifactId>buildnumber-maven-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.glassfish.build</groupId>
+                <artifactId>spec-version-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
             </plugin>


### PR DESCRIPTION
Related: #357
Verified that the manifest was complete when running locally: 

```txt
Manifest-Version: 1.0
Build-Id: 05/21/2026 08:47 AM
Build-Jdk-Spec: 17
Bundle-Description: Java API for JSON Binding (JSON-Binding)
Bundle-DocURL: https://www.eclipse.org
Bundle-License: https://projects.eclipse.org/license/epl-2.0, https://pr
 ojects.eclipse.org/license/secondary-gpl-2.0-cp
Bundle-ManifestVersion: 2
Bundle-Name: Jakarta JSON Binding API
Bundle-SymbolicName: jakarta.json.bind-api
Bundle-Vendor: Eclipse Foundation
Bundle-Version: 3.0.2
Created-By: Apache Maven Bundle Plugin 5.1.9
DynamicImport-Package: *
Export-Package: jakarta.json.bind;version="3.0";uses:="jakarta.json.bind
 .adapter,jakarta.json.bind.config,jakarta.json.bind.serializer,jakarta.
 json.bind.spi,jakarta.json.spi",jakarta.json.bind.adapter;version="3.0"
 ,jakarta.json.bind.annotation;version="3.0";uses:="jakarta.json.bind.ad
 apter,jakarta.json.bind.config,jakarta.json.bind.serializer",jakarta.js
 on.bind.config;version="3.0",jakarta.json.bind.serializer;version="3.0"
 ;uses:="jakarta.json.stream",jakarta.json.bind.spi;version="3.0";uses:=
 "jakarta.json.bind"
Extension-Name: jakarta.json.bind
Implementation-Version: 3.0.2
Import-Package: jakarta.json.bind;version="[3.0,4)",jakarta.json.bind.ad
 apter;version="[3.0,4)",jakarta.json.bind.config;version="[3.0,4)",jaka
 rta.json.bind.serializer;version="[3.0,4)",jakarta.json.bind.spi;versio
 n="[3.0,4)",jakarta.json.spi;version="[2.1,3)",jakarta.json.stream;vers
 ion="[2.1,3)",java.io,java.lang,java.lang.annotation,java.lang.invoke,j
 ava.lang.reflect,java.util,org.eclipse.yasson
Specification-Vendor: Oracle Corporation
Specification-Version: 3.0
Tool: Bnd-6.3.1.202206071316

```