### PR TITLE
Make project AI friendly

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Agent Rules
+
+## Start with the wiki
+
+At the start of each task, check `_context/index.md` to decide
+whether wiki context is needed before acting. Don't read the wiki in
+full. Use the index and follow links only when they are relevant to
+the task.
+
+## Update the wiki
+
+After completing a task, offer to update the wiki if the task yielded durable knowledge that could benefit future work,
+then wait for user approval. This includes new processes, architecture decisions, or insights that go beyond the immediate task.

--- a/_context/index.md
+++ b/_context/index.md
@@ -1,0 +1,28 @@
+# Jakarta JSON-B — Project
+
+Quick navigation for AI-assisted work on this repository.
+
+## Directories in context
+
+| Directory | Contents |
+| --------- | -------- |
+| plans/    | Plans for individual tasks that are temporary and discarded after completion |
+| releases/ | Plans for a single release which include descriptions of goals, individual tasks, and completion criteria |
+| wiki/     | A knowledge center for AI reference that encompases the scope of the entire project |
+
+### Files in the wiki
+
+| File | Contents |
+|------|----------|
+| [project.md](wiki/project.md) | Project overview, goals, key modules, stakeholders, release workflow |
+| [preferences.md](wiki/preferences.md) | Working standards, AI interaction preferences, Jakarta EE conventions |
+| [planning.md](wiki/planning.md) | Standard format for release plans: section structure, status values, and work-tracking rules |
+
+## When to reference context
+
+- **Always** read `wiki/project.md` when the task touches the api, spec, or tck — the triple-module constraint matters.
+- **Always** read `wiki/preferences.md` before generating code, spec text, or a plan so the output matches project conventions.
+- **Always** search `releases/` directory for a corresponding release plan, and read the plan, when you know which release is being worked on.
+- **When starting a task** check `plans/` for an existing plan file for the current task before creating a new one.
+- **Only when writing or updating a release plan** read `wiki/planning.md` for the required section structure, status values, and work-tracking rules.
+- Skip full reads of the `plans`, `releases`, and `wiki` directories; follow links only when relevant to the current task.

--- a/_context/index.md
+++ b/_context/index.md
@@ -16,7 +16,7 @@ Quick navigation for AI-assisted work on this repository.
 |------|----------|
 | [project.md](wiki/project.md) | Project overview, goals, key modules, stakeholders, release workflow |
 | [preferences.md](wiki/preferences.md) | Working standards, AI interaction preferences, Jakarta EE conventions |
-| [planning.md](wiki/planning.md) | Standard format for release plans: section structure, status values, and work-tracking rules |
+| [releases.md](wiki/releases.md) | Standard format for release plans: section structure, status values, and work-tracking rules |
 
 ## When to reference context
 
@@ -24,5 +24,5 @@ Quick navigation for AI-assisted work on this repository.
 - **Always** read `wiki/preferences.md` before generating code, spec text, or a plan so the output matches project conventions.
 - **Always** search `releases/` directory for a corresponding release plan, and read the plan, when you know which release is being worked on.
 - **When starting a task** check `plans/` for an existing plan file for the current task before creating a new one.
-- **Only when writing or updating a release plan** read `wiki/planning.md` for the required section structure, status values, and work-tracking rules.
+- **Only when writing or updating a release plan** read `wiki/releases.md` for the required section structure, status values, and work-tracking rules.
 - Skip full reads of the `plans`, `releases`, and `wiki` directories; follow links only when relevant to the current task.

--- a/_context/plans/.gitignore
+++ b/_context/plans/.gitignore
@@ -1,0 +1,3 @@
+# Ignore all plan files
+# These are ephemeral plans only used by a local developer
+.md

--- a/_context/releases/3.1.0.md
+++ b/_context/releases/3.1.0.md
@@ -1,0 +1,329 @@
+# Jakarta JSON Binding 3.1.0 — Release Plan
+
+> **Target platform:** Jakarta EE 12
+> **Milestone tracker:** https://github.com/jakartaee/jsonb-api/milestone/10
+> **Public release page:** https://jakarta.ee/specifications/jsonb/3.1/
+
+---
+
+## 0. Work-Item Status
+
+> **AI agents: read this table first.** Each row corresponds to a functional requirement defined in section 4.
+> Before acting on any FR, check its `Status` cell. Skip items marked `✅ DONE` — they are complete and must not be reopened or re-implemented.
+> Only act on items marked `⬜ TODO` or `🔄 IN PROGRESS`.
+
+| FR | Title | Modules | Status |
+|----|-------|---------|--------|
+| FR-1 | Java Record: Default Serialization | `api/`, `spec/`, `tck/` | ⬜ TODO |
+| FR-2 | Java Record: Default Deserialization | `api/`, `spec/`, `tck/` | ⬜ TODO |
+| FR-3 | Java Record: Annotation Support | `api/`, `spec/`, `tck/` | ⬜ TODO |
+| FR-4 | Java Record: Virtual Attributes | `api/`, `spec/`, `tck/` | ⬜ TODO |
+| FR-5 | UUID Default Mapping | `spec/`, `tck/` | ⬜ TODO |
+| FR-6 | Spec/API Name Consistency: @JsonbTypeSerializer/@JsonbTypeDeserializer | `spec/` | ⬜ TODO |
+| FR-7 | @JsonbPropertyOrder Semantic Clarification | `api/`, `spec/`, `docs/` | ⬜ TODO |
+| FR-8 | @JsonbNumberFormat Locale Documentation and TCK Coverage | `api/`, `tck/` | ⬜ TODO |
+| FR-9 | Java Record: Generic and Nested Usage | `spec/`, `tck/` | ⬜ TODO |
+
+---
+
+
+## 1. Goals and Expected Outcome
+
+Deliver Jakarta JSON Binding 3.1 as part of Jakarta EE 12 with:
+
+1. **Java Record support** — records serialize and deserialize through their canonical constructor; all existing customization annotations work on record components; no-arg virtual accessor methods are serialized by default.
+2. **Standardized UUID default mapping** — `java.util.UUID` is a required supported type in the default mapping, ending the implementation-specific variance that exists in 3.0.
+3. **Specification and API documentation corrections** — resolve known inconsistencies between the spec text, API Javadoc, and user guide that have caused interoperability confusion.
+4. **TCK health** — fix locale-sensitive and JDK-version-sensitive test failures so the TCK passes portably on any supported JDK and locale.
+
+---
+
+## 2. Target Users and Scenarios
+
+| User | Scenario |
+|------|----------|
+| Application developer | Serializes and deserializes Java records as data transfer objects without configuration. |
+| Application developer | Uses `@JsonbProperty`, `@JsonbTransient`, `@JsonbPropertyOrder`, `@JsonbCreator`, and polymorphism annotations on record components, expecting the same behavior as on POJO fields. |
+| Application developer | Serializes/deserializes `UUID` values in JSON and expects the same wire format (`"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"`) regardless of which compliant runtime is used. |
+| Framework author / library developer | Reads the specification and Javadoc to understand the contract for `@JsonbTypeSerializer` / `@JsonbTypeDeserializer` without encountering inconsistent naming. |
+| JSON-B implementation author | Runs the TCK against any JDK ≥ 21 and any locale and sees all tests pass without locale-specific workarounds. |
+| Spec committer / reviewer | Reads section 4.2 and the `@JsonbPropertyOrder` Javadoc and user guide and finds a consistent, unambiguous description of how property order is determined. |
+
+---
+
+## 3. Scope and Out of Scope
+
+### In scope
+
+- Java record serialization and deserialization (canonical constructor path)
+- Record component annotations: `@JsonbProperty`, `@JsonbTransient`, `@JsonbPropertyOrder`, `@JsonbCreator`, `@JsonbTypeInfo`, `@JsonbSubtype`
+- Record virtual attributes: no-arg instance methods that are not record components are serialized by default
+- `java.util.UUID` mandated in default mapping
+- Spec text fix: `@JsonbTypeSerializer` / `@JsonbTypeDeserializer` annotation name alignment (issue [#70](https://github.com/jakartaee/jsonb-api/issues/70))
+- Spec and user guide fix: `@JsonbPropertyOrder` clarification (issues [#63](https://github.com/jakartaee/jsonb-api/issues/63), [#371](https://github.com/jakartaee/jsonb-api/pull/371))
+- Spec Javadoc fix: `@JsonbNumberFormat` locale dependency documentation (issue [#362](https://github.com/jakartaee/jsonb-api/issues/362), already closed)
+- TCK fix: French locale number format test for JDK 13+ (issue [#272](https://github.com/jakartaee/jsonb-api/issues/272), already closed)
+- TCK challenge resolution: `NumberFormatCustomizationTest` locale behavior (issue [#360](https://github.com/jakartaee/jsonb-api/issues/360), already closed)
+- New TCK coverage for all record and UUID behaviors listed above (issue [#380](https://github.com/jakartaee/jsonb-api/issues/380))
+- Removal of Java `SecurityManager` references from spec and API (platform directive)
+- SEO-aligned specification document title update (platform directive)
+
+### Out of scope
+
+- GitHub Pages site overhaul (issue [#384](https://github.com/jakartaee/jsonb-api/issues/384))
+- New customization annotations beyond those already in the API
+- Removal of any existing API (no breaking changes)
+- Changes to the JSON-P layer or any other Jakarta EE specification
+
+---
+
+## 4. Functional Requirements
+
+Each requirement is independently testable and describes externally observable behavior.
+
+### FR-1 — Java Record: Default Serialization
+
+A Java record serialized with the default mapping produces a JSON object whose property names match the record component names in declaration order, and whose values are the serialized forms of the component values.
+
+**Linked issue:** [#380](https://github.com/jakartaee/jsonb-api/issues/380)  
+**Affected modules:** `api/`, `spec/`, `tck/`
+
+---
+
+### FR-2 — Java Record: Default Deserialization
+
+A JSON object deserialized into a Java record type is instantiated via the canonical constructor. Because a compact constructor's body is merged into the canonical constructor at compile time, the two are indistinguishable at runtime and both serve as the deserialization path. Any validation or normalization applied in a compact constructor is therefore automatically executed during deserialization. Each JSON property name is matched to the corresponding record component by name; components with no matching JSON property receive their default (null / zero / false) value. `@JsonbCreator` is the only mechanism to designate an alternative deserialization constructor.
+
+**Linked issue:** [#380](https://github.com/jakartaee/jsonb-api/issues/380)  
+**Affected modules:** `api/`, `spec/`, `tck/`
+
+---
+
+### FR-3 — Java Record: Annotation Support
+
+The annotations `@JsonbProperty`, `@JsonbTransient`, `@JsonbPropertyOrder` placed on record components produce the same observable serialization and deserialization behavior as when placed on POJO fields and accessor methods. `@JsonbCreator` placed on a record constructor designates that constructor as the deserialization path instead of the canonical constructor; because compact and canonical constructors are indistinguishable at runtime, `@JsonbCreator` is only meaningful when placed on a distinct non-canonical constructor. `@JsonbTypeInfo` and `@JsonbSubtype` placed on a record type support polymorphic mapping.
+
+**Linked issue:** [#380](https://github.com/jakartaee/jsonb-api/issues/380)  
+**Affected modules:** `api/`, `spec/`, `tck/`
+
+---
+
+### FR-4 — Java Record: Virtual Attributes
+
+A no-arg instance method declared on a record (not a record component accessor) is included in serialization output under the method name, unless annotated with `@JsonbTransient`. Virtual attributes are read-only: they are ignored during deserialization.
+
+**Linked issue:** [#399](https://github.com/jakartaee/jsonb-api/issues/399)  
+**Affected modules:** `api/`, `spec/`, `tck/`
+
+---
+
+### FR-5 — UUID Default Mapping
+
+`java.util.UUID` is a required type in the default mapping. Serialization produces the standard hyphenated lowercase string representation (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`). Deserialization parses that same format back to a `UUID` instance. Any compliant JSON-B implementation must support this without additional configuration.
+
+**Linked issue:** [#369](https://github.com/jakartaee/jsonb-api/issues/369)  
+**Affected modules:** `spec/`, `tck/` (API already contains `Jsonb` contract; spec default-mapping table needs UUID added)
+
+---
+
+### FR-6 — Spec/API Name Consistency: @JsonbTypeSerializer and @JsonbTypeDeserializer
+
+The specification document no longer refers to `@JsonbSerialized` or `@JsonbDeserialized`. Every normative reference uses the correct annotation names `@JsonbTypeSerializer` and `@JsonbTypeDeserializer` as defined in the API.
+
+**Linked issue:** [#70](https://github.com/jakartaee/jsonb-api/issues/70)  
+**Affected modules:** `spec/`
+
+---
+
+### FR-7 — @JsonbPropertyOrder Semantic Clarification
+
+The specification section 4.2 and the `@JsonbPropertyOrder` Javadoc unambiguously state that the annotation value is an explicit ordered list of **original** (pre-customization) property names. The user guide example uses an ordered name list, not a `PropertyOrderStrategy` constant.
+
+**Linked issues:** [#63](https://github.com/jakartaee/jsonb-api/issues/63), [#371](https://github.com/jakartaee/jsonb-api/pull/371)  
+**Affected modules:** `api/`, `spec/`, `docs/`
+
+---
+
+### FR-8 — @JsonbNumberFormat Locale Documentation and TCK Coverage
+
+The `@JsonbNumberFormat` Javadoc explicitly states that the formatted output is locale-dependent when no `locale` attribute is specified, and that portable JSON output requires specifying an explicit locale. TCK tests that use locale-sensitive patterns either specify `Locale.ROOT` or an explicit locale, or assert behavior only in the specified locale. A new TCK test must be written to verify that specifying an explicit locale in `@JsonbNumberFormat` produces the same formatted output regardless of the JVM default locale.
+
+**Linked issues:** [#362](https://github.com/jakartaee/jsonb-api/issues/362) (closed), [#360](https://github.com/jakartaee/jsonb-api/issues/360) (closed), [#272](https://github.com/jakartaee/jsonb-api/issues/272) (closed)
+**Affected modules:** `api/`, `tck/`
+
+---
+
+### FR-9 — Java Record: Generic and Nested Usage
+
+A Java record used as a type parameter (e.g. `List<Point>`, `Map<String, Point>`) or as a component type of another record follows the same mapping rules as a top-level record without additional configuration, consistent with how generic and nested POJOs behave. Type information is resolved through the full generic type signature supplied to the `Jsonb` API.
+
+**Linked issue:** [#380](https://github.com/jakartaee/jsonb-api/issues/380)
+**Affected modules:** `spec/`, `tck/`
+
+---
+
+## 5. Non-Functional Requirements
+
+| ID | Requirement | Measurable Threshold |
+|----|-------------|----------------------|
+| NFR-1 | Backward compatibility | Zero binary-incompatible changes to any `public` or `protected` type, method, or field in `api/`. All existing TCK tests that passed on 3.0 must continue to pass on 3.1 without modification to application code. |
+| NFR-2 | TCK portability | The full TCK suite passes with zero test failures on Java 21 LTS and Java 25 LTS, using any JVM default locale. |
+| NFR-3 | Spec/API synchrony | Every normative statement in the 3.1 spec document has a corresponding Javadoc paragraph in the API, and vice versa; no normative statement exists only in one artifact. |
+| NFR-4 | TCK completeness | Every normative sentence added or changed in the 3.1 spec (FRs 1–9) has at least one corresponding TCK test. |
+
+---
+
+## 6. Acceptance Criteria
+
+### AC-FR-1: Record Default Serialization
+
+**Given** a Java record `Point(int x, int y)` with values `x=1, y=2`  
+**When** serialized with `Jsonb.toJson(new Point(1, 2))`  
+**Then** the result is `{"x":1,"y":2}` with properties in declaration order.
+
+---
+
+### AC-FR-2a: Record Default Deserialization — All Fields Present
+
+**Given** the JSON string `{"x":1,"y":2}`  
+**When** deserialized into `Point(int x, int y)` via `Jsonb.fromJson(..., Point.class)`  
+**Then** the returned instance has `x == 1` and `y == 2` and was constructed via the canonical constructor.
+
+### AC-FR-2b: Record Default Deserialization — Missing Field
+
+**Given** the JSON string `{"x":5}`
+**When** deserialized into `Point(int x, int y)` via `Jsonb.fromJson(..., Point.class)`
+**Then** the returned instance has `x == 5` and `y == 0` (default value for `int`).
+
+### AC-FR-2c: Record Compact Constructor — Normalization Applied on Deserialization
+
+**Given** a record `Tag(String value)` with a compact constructor that normalizes `value` to uppercase (e.g. `value = value.toUpperCase()`)
+**When** the JSON string `{"value":"hello"}` is deserialized via `Jsonb.fromJson(..., Tag.class)`
+**Then** the returned instance has `value == "HELLO"` (normalization was applied through the canonical constructor path).
+
+---
+
+### AC-FR-3a: @JsonbProperty on Record Component
+
+**Given** a record `Person(@JsonbProperty("full_name") String name)`  
+**When** serialized  
+**Then** the JSON output contains the key `"full_name"` and not `"name"`.
+
+### AC-FR-3b: @JsonbTransient on Record Component
+
+**Given** a record `Credentials(String user, @JsonbTransient String password)`  
+**When** serialized  
+**Then** the JSON output contains `"user"` but does not contain `"password"`.
+
+### AC-FR-3c: @JsonbCreator on Record
+
+**Given** a record with `@JsonbCreator` on its canonical constructor  
+**When** deserialized from JSON  
+**Then** the annotated constructor is used and the object is created correctly.
+
+### AC-FR-3d: Polymorphism on Record
+
+**Given** a record type annotated with `@JsonbTypeInfo` and `@JsonbSubtype`  
+**When** serialized and then deserialized as the declared supertype  
+**Then** the correct record subtype is instantiated.
+
+---
+
+### AC-FR-4a: Record Virtual Attribute Included in Serialization
+
+**Given** a record `FullName(String first, String last)` with a method `String display() { return first + " " + last; }`  
+**When** serialized with default mapping  
+**Then** the JSON output contains `"display":"<computed value>"` in addition to `"first"` and `"last"`.
+
+### AC-FR-4b: @JsonbTransient Suppresses Virtual Attribute
+
+**Given** the same record with `@JsonbTransient` placed on `display()`  
+**When** serialized  
+**Then** the JSON output does not contain a `"display"` key.
+
+### AC-FR-4c: Virtual Attribute Ignored During Deserialization
+
+**Given** the JSON `{"first":"A","last":"B","display":"A B"}`  
+**When** deserialized into `FullName(String first, String last)`  
+**Then** `display` is silently ignored and no exception is thrown.
+
+---
+
+### AC-FR-5a: UUID Serialization
+
+**Given** a `UUID` value `550e8400-e29b-41d4-a716-446655440000`  
+**When** serialized with `Jsonb.toJson(uuid)`  
+**Then** the result is the JSON string `"550e8400-e29b-41d4-a716-446655440000"`.
+
+### AC-FR-5b: UUID Deserialization
+
+**Given** the JSON string `"550e8400-e29b-41d4-a716-446655440000"`  
+**When** deserialized with `Jsonb.fromJson(..., UUID.class)`  
+**Then** the result is the `UUID` value equal to `UUID.fromString("550e8400-e29b-41d4-a716-446655440000")`.
+
+---
+
+### AC-FR-6: Spec Uses Correct Annotation Names
+
+**Given** the published 3.1 specification document  
+**When** searching for `@JsonbSerialized` or `@JsonbDeserialized`  
+**Then** no occurrences are found; all references use `@JsonbTypeSerializer` and `@JsonbTypeDeserializer`.
+
+---
+
+### AC-FR-7a: @JsonbPropertyOrder Applies Original Names
+
+**Given** a type with a property `name` renamed to `full_name` via `@JsonbProperty`  
+**And** the type is also annotated with `@JsonbPropertyOrder({"name", "age"})`  
+**When** serialized  
+**Then** `full_name` appears before `age` in the output (annotation value uses original names).
+
+### AC-FR-7b: User Guide Example is Consistent with API
+
+**Given** the published user guide section on `@JsonbPropertyOrder`  
+**When** the example is read  
+**Then** the example uses an ordered list of property name strings, not a `PropertyOrderStrategy` constant.
+
+---
+
+### AC-FR-8a: @JsonbNumberFormat Javadoc Documents Locale Dependency
+
+**Given** the published 3.1 API Javadoc for `@JsonbNumberFormat`  
+**When** the locale behavior section is read  
+**Then** it states that output is locale-dependent when no `locale` attribute is provided, and recommends specifying an explicit locale for portable output.
+
+### AC-FR-8b: TCK Number Format Tests Are Locale-Portable
+
+**Given** the TCK tests for `@JsonbNumberFormat`  
+**When** executed on any JVM with any default locale  
+**Then** all tests pass without failure due to locale-specific decimal or grouping separator differences.
+
+### AC-FR-9a: Record as Generic Type Parameter — Serialization
+
+**Given** a `List<Point>` containing `[Point(1,2), Point(3,4)]`
+**When** serialized with `Jsonb.toJson(list)`
+**Then** the result is `[{"x":1,"y":2},{"x":3,"y":4}]`.
+
+### AC-FR-9b: Record as Generic Type Parameter — Deserialization
+
+**Given** the JSON string `[{"x":1,"y":2},{"x":3,"y":4}]`
+**When** deserialized with `Jsonb.fromJson(..., new TypeToken<List<Point>>(){}.getType())`
+**Then** the result is a `List<Point>` with two correctly populated `Point` instances.
+
+### AC-FR-9c: Nested Record — Record as Component of Another Record
+
+**Given** records `Address(String city)` and `Person(String name, Address address)`
+**When** `Person("Alice", new Address("Paris"))` is serialized
+**Then** the result is `{"name":"Alice","address":{"city":"Paris"}}`.
+
+### AC-FR-9d: Nested Record — Deserialization
+
+**Given** the JSON `{"name":"Alice","address":{"city":"Paris"}}`
+**When** deserialized into `Person(String name, Address address)`
+**Then** the returned `Person` has `name == "Alice"` and `address.city() == "Paris"`.
+
+---
+
+## 7. Assumptions and Open Questions
+<!-- Add any assumptions or open questions discovered through working sessions here -->
+_No outstanding work_

--- a/_context/wiki/planning.md
+++ b/_context/wiki/planning.md
@@ -1,0 +1,128 @@
+# Release Plan Format
+
+This document defines the standard format for release plan files in `_context/releases/`.
+Read this file whenever you are writing, updating, or interpreting a release plan.
+
+---
+
+## File location and naming
+
+Release plans live at `_context/releases/<version>.md` (e.g. `3.1.0.md`).
+One file per release. Do not create sub-files or split a plan across multiple documents.
+
+---
+
+## Standard sections
+
+Every release plan must contain the sections below in this order.
+
+### Section 0 — Work-Item Status *(required)*
+
+A tracking table that an AI agent reads **before any other section** to determine what
+work remains. It must appear immediately after the title block (target platform, milestone
+tracker, public release page).
+
+**Format:**
+
+```markdown
+## 0. Work-Item Status
+
+> **AI agents: read this table first.** Each row corresponds to a functional requirement
+> defined in section 4. Before acting on any FR, check its `Status` cell.
+> Skip items marked `✅ DONE` — they are complete and must not be reopened or re-implemented.
+> Only act on items marked `⬜ TODO` or `🔄 IN PROGRESS`.
+
+| FR | Title | Modules | Status |
+|----|-------|---------|--------|
+| FR-1 | <title> | `api/`, `spec/`, `tck/` | ⬜ TODO |
+```
+
+**Status values — use exactly these strings:**
+
+| Symbol | Meaning |
+|--------|---------|
+| `⬜ TODO` | Work has not started. Agent may begin this item. |
+| `🔄 IN PROGRESS` | Work has started but is not complete. Agent may continue this item. |
+| `✅ DONE` | Work is complete. Agent must skip this item entirely. |
+
+**Rules for agents:**
+- Read Section 0 first, every time, before reading the rest of the plan.
+- Never change a `✅ DONE` row back to any other status.
+- When completing an FR, update its status to `✅ DONE` in this table before finishing the task.
+- When starting an FR, update its status to `🔄 IN PROGRESS` to signal active work.
+
+---
+
+### Section 1 — Goals and Expected Outcome *(required)*
+
+A short numbered list of the high-level objectives for the release. Written for humans.
+Each goal should be one to three sentences. This section does not change once the plan is approved.
+
+---
+
+### Section 2 — Target Users and Scenarios *(required)*
+
+A Markdown table with columns `User` and `Scenario`. Describes who benefits and how.
+Does not change once the plan is approved.
+
+---
+
+### Section 3 — Scope and Out of Scope *(required)*
+
+Two subsections: **In scope** (bulleted list) and **Out of scope** (bulleted list).
+Each in-scope item should link to the relevant GitHub issue or pull request where one exists.
+Does not change once the plan is approved.
+
+---
+
+### Section 4 — Functional Requirements *(required)*
+
+One `###` subsection per FR, ID formatted as `FR-N`. Each FR subsection contains:
+
+- A plain-English description of the externally observable behavior.
+- `**Linked issue:**` — GitHub issue or PR number, linked.
+- `**Affected modules:**` — comma-separated list from `api/`, `spec/`, `tck/`, `docs/`.
+
+FR IDs must match the rows in the Section 0 status table exactly.
+
+---
+
+### Section 5 — Non-Functional Requirements *(required)*
+
+A Markdown table with columns `ID`, `Requirement`, and `Measurable Threshold`.
+IDs formatted as `NFR-N`. Does not change once the plan is approved.
+
+---
+
+### Section 6 — Acceptance Criteria *(required)*
+
+One or more `###` subsections per FR, formatted as `AC-FR-Na` (first criterion for FR-N),
+`AC-FR-Nb` (second criterion), etc. Each criterion uses Given / When / Then format.
+Does not change once the plan is approved.
+
+---
+
+### Section 7 — Assumptions and Open Questions *(required)*
+
+Free-form. Record unresolved decisions here during drafting. Mark each resolved item so the
+history is preserved. When all questions are resolved, replace the body with:
+`All outstanding questions have been resolved.`
+
+---
+
+## How to track progress
+
+1. **When starting work on an FR** — set its status to `🔄 IN PROGRESS` in the Section 0 table.
+2. **When work on an FR is fully complete** (API change merged, spec text merged, TCK tests merged) — set its status to `✅ DONE`.
+3. **Never** edit Section 0 for any other reason. All other sections are written once and remain stable.
+4. The release is complete when every row in Section 0 shows `✅ DONE`.
+
+---
+
+## Creating a new release plan
+
+1. Copy the section structure above.
+2. Fill in the title block (target platform, milestone tracker, public release page).
+3. Populate the Section 0 table with one row per FR, all starting at `⬜ TODO`.
+4. Complete sections 1–7.
+5. Get explicit approval from the spec lead before beginning implementation.

--- a/_context/wiki/preferences.md
+++ b/_context/wiki/preferences.md
@@ -32,7 +32,7 @@ These apply to every file touched in this repository.
 - **Always** produce a written plan and wait for explicit approval before modifying any file
 - Plan files go in the `_context/plans/` directory (e.g. `_context/plans/my-feature-plan.md`)
 - Plans must list affected modules (api, spec, tck) and why
-- When a task is complete, ask the user whether to **delete** the plan file (one-off task) or **record** it in the relevant `_context/releases/` file as a completed item
+- When a task is complete, ask the user whether to **delete** the plan file (one-off task) or **archive** it by recording the completed work in the relevant `_context/releases/` file (see `wiki/releases.md` for release plan format)
 
 ### Stay concise
 - Skip pleasantries and filler phrases — get straight to code, spec text, or analysis

--- a/_context/wiki/preferences.md
+++ b/_context/wiki/preferences.md
@@ -1,0 +1,59 @@
+# Working Preferences
+
+## Jakarta EE conventions
+
+These apply to every file touched in this repository.
+
+### Java / API (`api/`)
+- All public types, methods, and fields **must have Javadoc**
+- Javadoc must describe the contract, not the implementation
+- Tag new API with `@since <version>` (e.g. `@since 3.1`)
+- Deprecated API must carry `@deprecated` with a migration note; **never delete** deprecated API in the same release it was deprecated
+- Backward compatibility is the default — breaking changes require explicit spec committee approval
+- Follow existing package structure under `jakarta.json.bind.*`
+
+### Specification (`spec/`)
+- AsciiDoc source lives in `spec/src/main/asciidoc/`
+- Normative statements use RFC 2119 language (MUST, SHOULD, MAY, etc.)
+- Every API change that alters observable behaviour **must** update the spec text
+- Spec text and API Javadoc must be consistent — they are both normative
+
+### TCK (`tck/`)
+- Every normative spec statement must have at least one TCK test
+- Tests are Arquillian + JUnit 5; follow the patterns in existing test classes
+- Test class names mirror the behaviour under test (e.g. `CustomizedMappingTest`)
+- Add tests in the same PR as the API and spec changes — do not defer coverage
+
+---
+
+## AI interaction preferences
+
+### Plan first
+- **Always** produce a written plan and wait for explicit approval before modifying any file
+- Plan files go in the `_context/plans/` directory (e.g. `_context/plans/my-feature-plan.md`)
+- Plans must list affected modules (api, spec, tck) and why
+- When a task is complete, ask the user whether to **delete** the plan file (one-off task) or **record** it in the relevant `_context/releases/` file as a completed item
+
+### Stay concise
+- Skip pleasantries and filler phrases — get straight to code, spec text, or analysis
+- Use bullet points and tables over prose paragraphs
+- Only include context that directly affects a decision
+
+### Ask when uncertain
+- If a request is ambiguous (e.g. scope of a spec change, whether to deprecate vs remove), ask before proceeding
+- Surface trade-offs explicitly; do not silently pick one path
+- Prefer one focused question over several at once
+
+---
+
+## Communication preferences
+
+- Use **plan mode** for design and strategy; switch to **agent mode** only after the plan is approved
+- Prefix feedback or questions with `✏️` in plan files to make review edits easy to spot
+- Keep pull request descriptions concise: what changed, why, which modules were affected
+
+---
+
+## Additional preferences
+<!-- Add any preferences discovered through working sessions here -->
+_Nothing captured yet._

--- a/_context/wiki/project.md
+++ b/_context/wiki/project.md
@@ -1,0 +1,81 @@
+# Project Overview — Jakarta JSON Binding (JSON-B)
+
+## What this project is
+
+Jakarta JSON Binding (JSON-B) is a standard binding layer for the Jakarta EE platform that converts Java objects to and from JSON documents. It defines a set of Java interfaces, annotations, and an SPI that any compliant implementation must satisfy.
+
+- **Repository:** <https://github.com/jakartaee/jsonb-api>
+- **Java package root:** `jakarta.json.bind`
+- **Current development version:** 3.1.0-SNAPSHOT
+- **License:** EPL 2.0 / GPL 2.0 with Classpath Exception
+
+---
+
+## Main goals and objectives
+
+Goals are organised into **releases**. Each release targets a defined subset of objectives. Capture active release goals below as they are established.
+
+### Standing goals (every release)
+- Evolve the specification and API surface in a backward-compatible way
+- Keep TCK coverage complete — every normative statement must have at least one test
+- Keep spec text and API Javadoc in sync
+- Coordinate compatible implementation alignment with Eclipse Yasson before a release
+
+### Active release goals
+
+Are found in the `_context/releases/` directory and are organized into individual plans based on the release version. For example the plan for release version 3.1.0 would be in the `_context/releases/3.1.0.md` file.
+
+---
+
+## Key stakeholders and collaborators
+
+| Stakeholder | Role |
+|-------------|------|
+| Spec leads (Nathan Rauh & Dmitry Kornilov) | Final authority on specification decisions |
+| Fellow spec committers | Co-authors of API changes and spec text |
+| Eclipse Yasson team | Eclipse managed compatible implementation |
+| Jakarta EE platform committee | Coordinates inclusion of JSON-B releases into platform releases |
+| Community contributors | Submit issues and pull requests via GitHub |
+
+---
+
+## Repository modules
+
+Every significant change typically touches **all three** modules. They must stay in sync.
+
+| Module | Path | Purpose |
+|--------|------|---------|
+| **API** | [`api/`](../api/) | Java interfaces, annotations, and SPI classes; the public contract |
+| **Specification** | [`spec/`](../spec/) | Normative AsciiDoc document; must reflect every API change |
+| **TCK** | [`tck/`](../tck/) | Technology Compatibility Kit; Arquillian + JUnit 5 tests that verify conformance |
+| TCK distribution | [`tck-dist/`](../tck-dist/) | Packaged TCK for third-party implementors |
+| Docs | [`docs/`](../docs/) | Generated documentation using Asciidoctor |
+
+### Change rule
+> An API change is not complete until matching spec text and TCK coverage exist.
+
+---
+
+## Important workflows
+
+### Feature / change workflow
+1. Open or link a GitHub issue
+2. Draft API change in `api/` with full Javadoc
+3. Write or update the corresponding spec chapter in `spec/`
+4. Add TCK tests in `tck/` that cover the new normative behaviour
+5. Coordinate with implementation teams to confirm implementability
+6. Open a pull request; get spec committer review
+7. Merge after approval; tag release when the milestone is complete
+
+### Build
+```bash
+mvn clean install        # full build: API + spec + TCK
+mvn -pl api clean install  # API module only
+mvn -pl tck clean install  # TCK module only
+```
+
+---
+
+## Additional context
+<!-- Add architecture decisions, recurring patterns, or insights from past tasks here -->
+_Nothing captured yet._

--- a/_context/wiki/project.md
+++ b/_context/wiki/project.md
@@ -6,7 +6,7 @@ Jakarta JSON Binding (JSON-B) is a standard binding layer for the Jakarta EE pla
 
 - **Repository:** <https://github.com/jakartaee/jsonb-api>
 - **Java package root:** `jakarta.json.bind`
-- **Current development version:** 3.1.0-SNAPSHOT
+- **Current development version:** 3.1.0
 - **License:** EPL 2.0 / GPL 2.0 with Classpath Exception
 
 ---
@@ -23,7 +23,7 @@ Goals are organised into **releases**. Each release targets a defined subset of 
 
 ### Active release goals
 
-Are found in the `_context/releases/` directory and are organized into individual plans based on the release version. For example the plan for release version 3.1.0 would be in the `_context/releases/3.1.0.md` file.
+Are found in the `_context/releases/` directory and are organized into individual plans based on the release version. For example the plan for release version 1.1.0 would be in the `_context/releases/1.1.0.md` file.
 
 ---
 
@@ -31,7 +31,7 @@ Are found in the `_context/releases/` directory and are organized into individua
 
 | Stakeholder | Role |
 |-------------|------|
-| Spec leads (Nathan Rauh & Dmitry Kornilov) | Final authority on specification decisions |
+| Spec leads | Final authority on specification decisions |
 | Fellow spec committers | Co-authors of API changes and spec text |
 | Eclipse Yasson team | Eclipse managed compatible implementation |
 | Jakarta EE platform committee | Coordinates inclusion of JSON-B releases into platform releases |

--- a/_context/wiki/releases.md
+++ b/_context/wiki/releases.md
@@ -12,7 +12,7 @@ Read this file whenever you are writing, updating, or interpreting a **release p
 
 ## File location and naming
 
-Release plans live at `_context/releases/<version>.md` (e.g. `3.1.0.md`).
+Release plans live at `_context/releases/<version>.md` (e.g. `1.1.0.md`).
 One file per release. Do not create sub-files or split a plan across multiple documents.
 
 ---
@@ -32,7 +32,8 @@ tracker, public release page).
 ```markdown
 ## 0. Work-Item Status
 
-> **AI agents: read this table first.** Each row corresponds to a functional requirement
+> **AI agents: read this table first.**
+> Each row corresponds to a functional requirement
 > defined in section 4. Before acting on any FR, check its `Status` cell.
 > Skip items marked `✅ DONE` — they are complete and must not be reopened or re-implemented.
 > Only act on items marked `⬜ TODO` or `🔄 IN PROGRESS`.

--- a/_context/wiki/releases.md
+++ b/_context/wiki/releases.md
@@ -1,7 +1,12 @@
 # Release Plan Format
 
 This document defines the standard format for release plan files in `_context/releases/`.
-Read this file whenever you are writing, updating, or interpreting a release plan.
+Read this file whenever you are writing, updating, or interpreting a **release plan**.
+
+> **Scope:** This file covers release planning only — goals, FRs, acceptance criteria, and
+> progress tracking for a named version. It does **not** apply to individual task plans stored
+> in `_context/plans/`. For task-level planning, refer to `wiki/preferences.md` and the task
+> context directly.
 
 ---
 
@@ -126,3 +131,15 @@ history is preserved. When all questions are resolved, replace the body with:
 3. Populate the Section 0 table with one row per FR, all starting at `⬜ TODO`.
 4. Complete sections 1–7.
 5. Get explicit approval from the spec lead before beginning implementation.
+
+---
+
+## Recording completed task work
+
+When a task plan in `_context/plans/` is finished, the agent must ask the user whether to
+**delete** the plan file or **archive** it into the release plan. If archiving:
+
+1. Locate the matching FR row in Section 0 of the relevant `_context/releases/<version>.md`.
+2. Set its status to `✅ DONE`.
+3. Do not modify any other section — sections 1–7 are written once and remain stable.
+4. Delete the task plan file from `_context/plans/` after the release plan is updated.


### PR DESCRIPTION
Add an `AGENTS.md` file with corresponding `_context/` directory so that all AI agents used by contributors to this project have a standard set of context/preferences/rules to follow to when making contributions to this project. 
This should improve the content of AI driven development in this project.