### PR TITLE
fix: build errors with documentation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,17 +62,17 @@ jobs:
         fi
     - name: Assemble documentation
       run: |
-        DEST=_site/${{ steps.target_dir.outputs.subdir }}
-        mkdir -p "$DEST/docs"
-        mkdir -p "$DEST/api"
-        mkdir -p "$DEST/tck"
+        mkdir -p "_site/docs"
+        mkdir -p "_site/api"
+        mkdir -p "_site/tck"
 
         cp README.md "_site/README.md"
-        cp docs/target/generated-docs/user-guide.html "$DEST/docs/index.html"
-        cp -r api/target/apidocs/ "$DEST/api/"
-        cp tck-dist/target/generated-docs/jsonb-tck-reference-guide-*.html "$DEST/tck/index.html"
+        cp docs/target/generated-docs/user-guide.html "_site/docs/index.html"
+        cp -r api/target/apidocs/ "_site/api/"
+        cp tck-dist/target/generated-docs/jsonb-tck-reference-guide-*.html "_site/tck/index.html"
     - name: Deploy to GitHub Pages
       uses: jamesives/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
       with:
         folder: _site
         branch: gh-pages
+        target-folder: ${{ steps.target_dir.outputs.subdir }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,6 +27,10 @@ on:
   push:
     branches:
       - 'main'
+    paths: # Limit rebuilding the site to only when the following directories are changed.
+      - 'docs/src/**'
+      - 'api/src/**'
+      - 'tck-dist/src/**'
   release:
     types: [published]
   workflow_dispatch: #For testing purposes
@@ -59,19 +63,18 @@ jobs:
         fi
     - name: Assemble documentation
       run: |
-        DEST=site/${{ steps.target_dir.outputs.subdir }}
+        DEST=_site/${{ steps.target_dir.outputs.subdir }}
         mkdir -p "$DEST/docs"
         mkdir -p "$DEST/api"
         mkdir -p "$DEST/tck"
 
+        cp README.md "_site/README.md"
         cp docs/target/generated-docs/user-guide.html "$DEST/docs/index.html"
-        cp -r api/target/apidocs/. "$DEST/api/"
+        cp -r api/target/apidocs/ "$DEST/api/"
         cp tck-dist/target/generated-docs/jsonb-tck-reference-guide-*.html "$DEST/tck/index.html"
     - name: Upload pages artifact
       id: deployment
       uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-      with:
-        path: ./site/${{ steps.target_dir.outputs.subdir }}
 
   deploy:
     needs: build

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,8 +37,7 @@ on:
 
 # pages: write and id-token: write are required by actions/deploy-pages.
 permissions:
-  pages: write
-  id-token: write
+  contents: write
 
 jobs:
   build:
@@ -72,17 +71,8 @@ jobs:
         cp docs/target/generated-docs/user-guide.html "$DEST/docs/index.html"
         cp -r api/target/apidocs/ "$DEST/api/"
         cp tck-dist/target/generated-docs/jsonb-tck-reference-guide-*.html "$DEST/tck/index.html"
-    - name: Upload pages artifact
-      id: deployment
-      uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy.outputs.page_url }}
-    steps:
     - name: Deploy to GitHub Pages
-      id: deploy
-      uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+      uses: jamesives/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
+      with:
+        folder: _site
+        branch: gh-pages

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -52,7 +52,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build documentation
-      run: mvn -B clean package
+      run: mvn -B clean package -DskipTests -Prelease
     - name: Determine target subdirectory
       id: target_dir
       run: |


### PR DESCRIPTION
Sorry for the extra PR.
Follow up to https://github.com/jakartaee/jsonb-api/pull/402

I had some errors in the previous workflow that are addressed here: 
- Limit rebuilding the site to only when the certain directories are updated
- Skip unit tests and actually generate javadoc
- Push documentation to branch gh-pages/<target-release> instead of directly publishing to the page (without source)

I tested this in my own branch, and the workflow passed: 
- workflow: https://github.com/KyleAure/jsonb-api/actions/runs/31201076842

And produced the following directory: 
- https://github.com/KyleAure/jsonb-api/tree/gh-pages/SNAPSHOT